### PR TITLE
More flexible handling of change WW requests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -218,6 +218,15 @@ class DeviceControlCenterSkill(NeonSkill):
                     LOG.debug(f"Found ww: {matched_ww}")
                     break
         if not matched_ww:
+            LOG.warning("Checking for known wake words")
+            if self.voc_match(requested_ww, 'mycroft') and \
+                    'hey_mycroft' in available_ww.keys():
+                matched_ww = 'hey_mycroft'
+            elif self.voc_match(requested_ww, 'neon') and \
+                    'hey_neon' in available_ww.keys():
+                matched_ww = 'hey_neon'
+
+        if not matched_ww:
             LOG.debug(f"No valid ww matched in: {requested_ww}")
             if message.data.get("rx_wakeword"):
                 self.speak_dialog("error_invalid_ww_requested",

--- a/locale/en-us/vocab/change.voc
+++ b/locale/en-us/vocab/change.voc
@@ -2,3 +2,4 @@ change
 update
 modify
 set
+make

--- a/locale/en-us/vocab/mycroft.voc
+++ b/locale/en-us/vocab/mycroft.voc
@@ -1,0 +1,2 @@
+mycroft
+microsoft

--- a/locale/en-us/vocab/neon.voc
+++ b/locale/en-us/vocab/neon.voc
@@ -1,0 +1,3 @@
+neon
+nyan
+leon

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -76,3 +76,4 @@ en-us:
     - update my wakeword to hello:
         rx_wakeword: hello
     - change my wake word okay
+    - make my wake word something

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -6,7 +6,7 @@ languages:
 
 # vocab is lowercase .voc file basenames
 vocab:
-  - change
+  - "change"
   - "debug"
   - "disable"
   - "enable"
@@ -22,6 +22,8 @@ vocab:
   - "stop"
   - "stop_sww"
   - "ww"
+  - "mycroft"
+  - "neon"
 
 # dialog is .dialog file basenames (case-sensitive)
 dialog:

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -553,6 +553,7 @@ class TestSkill(unittest.TestCase):
         self.skill.change_ww(message_change_hey_neon)
         self.skill.speak_dialog.assert_called_with("error_ww_already_enabled",
                                                    {"requested_ww": "hey neon"})
+        self.skill.speak_dialog.reset_mock()
 
         # Test already enabled alternate utterance
         message_change_hey_neon_alt = Message(
@@ -563,6 +564,16 @@ class TestSkill(unittest.TestCase):
                          "change my wake word to hey neon"
                      ]})
         self.skill.change_ww(message_change_hey_neon_alt)
+        self.skill.speak_dialog.assert_called_with("error_ww_already_enabled",
+                                                   {"requested_ww": "hey neon"})
+        self.skill.speak_dialog.reset_mock()
+
+        # Test already enabled voc match
+        message_change_neon = Message(
+            "test", {"rx_wakeword": "neon",
+                     "utterance": "change my wakeword to neon",
+                     "utterances": []})
+        self.skill.change_ww(message_change_neon)
         self.skill.speak_dialog.assert_called_with("error_ww_already_enabled",
                                                    {"requested_ww": "hey neon"})
 


### PR DESCRIPTION
# Description
Handle "make my wake word..." intent with intent test
Add voc_match fallback for known "neon" and "mycroft" wake words with tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->