### PR TITLE
Prompt to disable other WWs when user requests "changing" to an active one

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -256,11 +256,13 @@ class DeviceControlCenterSkill(NeonSkill):
                 LOG.info(f"Multiple WW active")
                 for ww in enabled_ww:
                     if ww != matched_ww:
+                        spoken_ww = ww.replace("_", " ")
                         resp = self.ask_yesno("ask_disable_ww",
-                                              {"ww": ww.replace("_", " ")})
+                                              {"ww": spoken_ww})
                         if resp == "yes":
                             if self._disable_wake_word(ww, message):
-                                self.speak_dialog("confirm_ww_disabled")
+                                self.speak_dialog("confirm_ww_disabled",
+                                                  {"ww": spoken_ww})
                             else:
                                 pass
                                 # TODO: Speak error

--- a/__init__.py
+++ b/__init__.py
@@ -252,15 +252,25 @@ class DeviceControlCenterSkill(NeonSkill):
         if matched_ww in enabled_ww:
             self.speak_dialog("error_ww_already_enabled",
                               {"requested_ww": matched_ww.replace("_", " ")})
+            if len(enabled_ww) > 1:
+                LOG.info(f"Multiple WW active")
+                for ww in enabled_ww:
+                    if ww != matched_ww:
+                        resp = self.ask_yesno("ask_disable_ww",
+                                              {"ww": ww.replace("_", " ")})
+                        if resp == "yes":
+                            if self._disable_wake_word(ww, message):
+                                self.speak_dialog("confirm_ww_disabled")
+                            else:
+                                pass
+                                # TODO: Speak error
+
             return
 
         self.speak_dialog("confirm_ww_changing")
-        # This has to reload the recognizer loop, so allow more time to respond
-        resp = self.bus.wait_for_response(message.forward(
-            "neon.enable_wake_word", {"wake_word": matched_ww}), timeout=30)
-        if not resp or resp.data.get('error'):
-            LOG.error(f"Error response resp={resp}")
+        if not self._enable_wake_word(matched_ww, message):
             self.speak_dialog("error_ww_change_failed")
+            # TODO: If this is a timeout, the new WW might be active
             return
 
         new_ww = matched_ww.replace('_', ' ')
@@ -270,10 +280,8 @@ class DeviceControlCenterSkill(NeonSkill):
         if len(enabled_ww) == 1:
             old_ww = enabled_ww[0]
             LOG.debug(f"Disable old WW: {old_ww}")
-            resp = self.bus.wait_for_response(message.forward(
-                "neon.disable_wake_word", {"wake_word": old_ww}), timeout=30)
-            if not resp or resp.data.get("error"):
-                LOG.error(resp)
+            self._disable_wake_word(old_ww, message)
+            # TODO: Something different if this fails
 
             self.speak_dialog("confirm_ww_changed", {"wake_word": new_ww})
         else:
@@ -282,6 +290,39 @@ class DeviceControlCenterSkill(NeonSkill):
 
     def stop(self):
         pass
+
+    def _enable_wake_word(self, ww: str, message: Message) -> bool:
+        """
+        Enable the requested wake word and return True on success
+        :param ww: string wake word to enable
+        :returns: True on success, False on failure
+        """
+        # This has to reload the recognizer loop, so allow more time to respond
+        resp = self.bus.wait_for_response(message.forward(
+            "neon.enable_wake_word", {"wake_word": ww}), timeout=30)
+        if not resp:
+            LOG.error("No response to WW enable request")
+            return False
+        if resp.data.get('error'):
+            LOG.warning(f"WW enable failed with response: {resp.data}")
+            return False
+        return True
+
+    def _disable_wake_word(self, ww: str, message: Message) -> bool:
+        """
+        Disable the requested wake word and return True on success
+        :param ww: string wake word to disable
+        :returns: True on success, False on failure
+        """
+        resp = self.bus.wait_for_response(message.forward(
+            "neon.disable_wake_word", {"wake_word": ww}), timeout=30)
+        if not resp:
+            LOG.error("No response to WW disable request")
+            return False
+        if resp.data.get('error'):
+            LOG.warning(f"WW disable failed with response: {resp.data}")
+            return False
+        return True
 
     def _do_exit_shutdown(self, action: SystemCommand):
         """

--- a/locale/en-us/dialog/ask_disable_ww.dialog
+++ b/locale/en-us/dialog/ask_disable_ww.dialog
@@ -1,0 +1,1 @@
+Would you like to disable the wake word {{ww}}?

--- a/locale/en-us/dialog/confirm_ww_disabled.dialog
+++ b/locale/en-us/dialog/confirm_ww_disabled.dialog
@@ -1,0 +1,1 @@
+Okay, I will stop listening for "{{ww}}".

--- a/locale/en-us/vocab/ww.voc
+++ b/locale/en-us/vocab/ww.voc
@@ -8,3 +8,4 @@ awakewords
 weightwords
 weward
 wakeward
+wekeward

--- a/locale/en-us/vocab/ww.voc
+++ b/locale/en-us/vocab/ww.voc
@@ -7,3 +7,4 @@ wakewords
 awakewords
 weightwords
 weward
+wakeward

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -51,6 +51,8 @@ dialog:
   - error_ww_already_enabled
   - error_ww_change_failed
   - confirm_ww_changing
+  - ask_disable_ww
+  - confirm_ww_disabled
 
 # regex entities, not necessarily filenames
 regex:

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -621,14 +621,40 @@ class TestSkill(unittest.TestCase):
                                                   "active": False,
                                                   "wake_word": ww}))
 
-        self.skill.bus.once("neon.enable_wake_word", _handle_enable_ww)
-        self.skill.bus.once("neon.disable_wake_word", _handle_disable_ww)
+        self.skill.bus.on("neon.enable_wake_word", _handle_enable_ww)
+        self.skill.bus.on("neon.disable_wake_word", _handle_disable_ww)
 
         self.skill.handle_change_ww(message_change_hey_mycroft)
         self.assertTrue(wake_word_config['hey_mycroft']['active'])
         self.assertFalse(wake_word_config['hey_neon']['active'])
         self.skill.speak_dialog.assert_called_with("confirm_ww_changed",
                                                    {"wake_word": "hey my-croft"})
+
+        # Test already enabled, disable other
+        wake_word_config['hey_neon']['active'] = True
+        self.assertTrue(wake_word_config['hey_mycroft']['active'])
+        self.assertTrue(wake_word_config['hey_neon']['active'])
+
+        real_ask_yesno = self.skill.ask_yesno
+        self.skill.ask_yesno = Mock(return_value="no")
+        self.skill.handle_change_ww(message_change_hey_neon)
+        self.skill.ask_yesno.assert_called_once_with("ask_disable_ww",
+                                                     {"ww": "hey mycroft"})
+        self.assertTrue(wake_word_config['hey_mycroft']['active'])
+        self.assertTrue(wake_word_config['hey_neon']['active'])
+
+        self.skill.ask_yesno.return_value = "yes"
+        self.skill.handle_change_ww(message_change_hey_mycroft)
+        self.skill.ask_yesno.assert_called_with("ask_disable_ww",
+                                                {"ww": "hey neon"})
+        self.skill.speak_dialog.assert_called_with("confirm_ww_disabled")
+        self.assertTrue(wake_word_config['hey_mycroft']['active'])
+        self.assertFalse(wake_word_config['hey_neon']['active'])
+
+        self.skill.ask_yesno = real_ask_yesno
+
+        self.skill.bus.remove("neon.enable_wake_word", _handle_enable_ww)
+        self.skill.bus.remove("neon.disable_wake_word", _handle_disable_ww)
 
         # Test change no response
         self.skill.handle_change_ww(message_change_hey_neon)
@@ -646,6 +672,14 @@ class TestSkill(unittest.TestCase):
         self.skill.handle_change_ww(message_change_hey_neon)
         self.skill.speak_dialog.assert_called_with("error_ww_change_failed")
         disable_ww.assert_not_called()
+
+    def test_enable_ww(self):
+        pass
+        # TODO
+
+    def test_disable_ww(self):
+        pass
+        # TODO
 
 
 if __name__ == '__main__':

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -647,7 +647,8 @@ class TestSkill(unittest.TestCase):
         self.skill.handle_change_ww(message_change_hey_mycroft)
         self.skill.ask_yesno.assert_called_with("ask_disable_ww",
                                                 {"ww": "hey neon"})
-        self.skill.speak_dialog.assert_called_with("confirm_ww_disabled")
+        self.skill.speak_dialog.assert_called_with("confirm_ww_disabled",
+                                                   {"ww": "hey neon"})
         self.assertTrue(wake_word_config['hey_mycroft']['active'])
         self.assertFalse(wake_word_config['hey_neon']['active'])
 


### PR DESCRIPTION
# Description
Update skill to prompt for disabling other wake words when requesting to "change" to an active one

Update resource and unit tests to accommodate new functionality Restructure skill to enable future intents to enable/disable specific WWs

# Issues
Relates to #67 
Contributes to #68

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->