### PR TITLE
Update OVOS dependencies to allow 0.x versions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,9 +28,8 @@
 
 from typing import Optional
 from enum import Enum
-from adapt.intent import IntentBuilder
 from random import randint
-from ovos_bus_client import Message
+from ovos_bus_client.message import Message
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
@@ -38,6 +37,7 @@ from neon_utils.message_utils import dig_for_message
 from neon_utils.skills.neon_skill import NeonSkill
 from neon_utils.validator_utils import numeric_confirmation_validator
 from ovos_workshop.decorators import intent_handler
+from ovos_workshop.intents import IntentBuilder
 
 
 class SystemCommand(Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 neon-utils~=1.0
 ovos-utils~=0.0, >=0.0.28
-ovos-bus-client~=0.0.3
-ovos-workshop~=0.0.15
-adapt-parser<2.0,>=0.5
+ovos-bus-client~=0.0,>=0.0.3
+ovos-workshop~=0.0,>=0.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-neon-utils~=1.0
+# TODO: network patching dependency resolution
+neon-utils[network]~=1.8,>=1.11.1a3
 ovos-utils~=0.0, >=0.0.28
 ovos-bus-client~=0.0,>=0.0.3
 ovos-workshop~=0.0,>=0.0.15

--- a/skill.json
+++ b/skill.json
@@ -16,7 +16,7 @@
     "systemDeps": false,
     "requirements": {
         "python": [
-            "neon-utils~=1.0",
+            "neon-utils[network]~=1.8,>=1.11.1a3",
             "ovos-bus-client~=0.0,>=0.0.3",
             "ovos-utils~=0.0, >=0.0.28",
             "ovos-workshop~=0.0,>=0.0.15"

--- a/skill.json
+++ b/skill.json
@@ -16,11 +16,10 @@
     "systemDeps": false,
     "requirements": {
         "python": [
-            "adapt-parser<2.0,>=0.5",
             "neon-utils~=1.0",
-            "ovos-bus-client~=0.0.3",
+            "ovos-bus-client~=0.0,>=0.0.3",
             "ovos-utils~=0.0, >=0.0.28",
-            "ovos-workshop~=0.0.15"
+            "ovos-workshop~=0.0,>=0.0.15"
         ],
         "system": {},
         "skill": []


### PR DESCRIPTION
# Description
Update ovos-workshop and ovos-bus-client dependencies
Replace `adapt.intent` import with `ovos-workshop` wrapper

# Issues
https://github.com/NeonGeckoCom/NeonCore/pull/708

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->